### PR TITLE
Add MiniMax M2.7 model option

### DIFF
--- a/flutter_app/lib/models/ai_provider.dart
+++ b/flutter_app/lib/models/ai_provider.dart
@@ -142,6 +142,7 @@ class AiProvider {
     baseUrl: 'https://api.minimax.io/v1',
     defaultModels: [
       'MiniMax-M3',
+      'MiniMax-M2.7',
     ],
     apiKeyHint: 'sk-...',
   );


### PR DESCRIPTION
Reason: Add the missing MiniMax M2.7 model to the existing MiniMax selector.

- Added MiniMax-M2.7 alongside MiniMax-M3 in the Flutter provider catalog.

- No API or configuration behavior was changed.
Checks:
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MiniMax-M2.7 to the MiniMax provider so users can select it alongside MiniMax-M3 in the Flutter app. No API, configuration, or behavior changes.

- Adds MiniMax-M2.7 to AiProvider.defaultModels for MiniMax; it appears in the provider selector.
- No migration required; existing configurations and selections continue to work.

<sup>Written for commit b77f5f307f956c7989be1f3c1fcfdf50b2c8ca48. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/mithun50/openclaw-termux/pull/146?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the MiniMax-M2.7 model as an available default AI model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->